### PR TITLE
Restrict words based on gender

### DIFF
--- a/src/components/LocalData.ts
+++ b/src/components/LocalData.ts
@@ -13,6 +13,7 @@ export interface ILocalDataV1 {
     scores: IScores;
     settings: {
         selectedCases: number[];
+        selectedGenders: number[];
     };
 }
 
@@ -31,6 +32,7 @@ export class LocalData {
         },
         settings: {
             selectedCases: [2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14],
+            selectedGenders: [0, 1, 2, 3],
         },
     };
 
@@ -59,6 +61,16 @@ export class LocalData {
         const newLocalData = {
             ...localData,
             settings: { ...localData.settings, selectedCases: Array.from(selectedCases.values()) },
+        };
+        this.localDataPromise = Promise.resolve(newLocalData);
+        return this.saveLocalData();
+    };
+
+    public setSelectedGenders = async (selectedGenders: Set<number>) => {
+        const localData = await this.localDataPromise;
+        const newLocalData = {
+            ...localData,
+            settings: { ...localData.settings, selectedGenders: Array.from(selectedGenders.values()) },
         };
         this.localDataPromise = Promise.resolve(newLocalData);
         return this.saveLocalData();


### PR DESCRIPTION
Some people have requested the ability to limit the the gender of provided words, to be able to focus on practicing specific genders they're struggling with.

This change adds an extra section of check boxes to let a user select the genders they want. When a new word is requested, it will check to make sure the randomly selected word meets the requested genders.

Happy to revise if I've done things wonky, this is the first time I've really done anything with TypeScript. I've used the website a ton to practice declension, and it's been very helpful, so extending it seems like a worthy cause :) 